### PR TITLE
Reset both `type` and `selectedFeatures` on "Start Over"

### DIFF
--- a/main/src/main/js/launch/src/App.jsx
+++ b/main/src/main/js/launch/src/App.jsx
@@ -36,10 +36,11 @@ import { parseQuery } from './helpers/url'
 const formResets = () => ({
   name: 'demo',
   package: 'com.example',
+  type: 'DEFAULT',
 })
+
 const initialForm = () => ({
   ...formResets(),
-  type: 'DEFAULT',
   javaVersion: '',
 })
 
@@ -287,8 +288,9 @@ export default function App() {
 
   const onStartOver = () => {
     setForm((form) => ({ ...form, ...formResets() }))
+    removeAllFeatures()
     setNextStepsInfo({})
-  }
+}
 
   const onCloseNextSteps = () => {
     setNextStepsInfo({})


### PR DESCRIPTION
- addresses https://github.com/micronaut-projects/micronaut-starter-ui/issues/19

We're still leaving a few things in place that straddle the line between application configuration and user preferences.
For example if the use has chosen Groovy / Maven / Spock we'll keep those as the next starting point, rather than resetting back to Java / Gradle / Junit.

