### PR TITLE
Change label for JUnit

### DIFF
--- a/main/src/main/js/launch/src/micronaut/LocalSelectOptions.json
+++ b/main/src/main/js/launch/src/micronaut/LocalSelectOptions.json
@@ -141,7 +141,7 @@
                 "name": "junit",
                 "description": "junit",
                 "value": "JUNIT",
-                "label": "Junit"
+                "label": "JUnit"
             },
             {
                 "name": "spock",
@@ -160,7 +160,7 @@
             "name": "junit",
             "description": "junit",
             "value": "JUNIT",
-            "label": "Junit"
+            "label": "JUnit"
         }
     },
     "build": {


### PR DESCRIPTION
https://micronaut.io/launch/ currently lists "Junit" as a test framework but the correct spelling is "JUnit".

I didn't test the change locally but it seems pretty obvious where to change it.