### PR TITLE
Address issues with oversized modal heading text.

### DIFF
--- a/main/src/main/js/launch/src/styles/modal-overrides.css
+++ b/main/src/main/js/launch/src/styles/modal-overrides.css
@@ -1,81 +1,65 @@
 .modal {
-    width: 35%;
-    min-width: 320px;
-    z-index: 9998 !important;
+  width: 35%;
+  min-width: 320px;
+  z-index: 9998 !important;
 }
 
-.modal.preview h4 {
-    padding-bottom: 10px;
-    margin-bottom: 0;
-    position: fixed;
-}
-
+.modal.preview h4,
 .modal.diff h4 {
-    padding-bottom: 10px;
-    margin-bottom: 0;
-    position: fixed;
+  font-size: 1.3rem;
+  padding-bottom: 10px;
+  margin-bottom: 0;
+  position: fixed;
+}
+
+.modal.next-steps h5 {
+  font-size: 1.3rem;
 }
 
 .modal.modal-lg {
-    width: 65%;
+  width: 65%;
 }
 
 .modal.modal-xl {
-    width: 90%;
+  width: 90%;
 }
 
 .modal.mn-feature-modal,
 .modal.preview {
-    width: 75%;
-    max-height: 90%;
-    height: 90%;
+  width: 75%;
+  max-height: 90%;
+  height: 90%;
 }
 
 .modal.diff {
-    width: 75%;
-    max-height: 90%;
-    height: 90%;
+  width: 75%;
+  max-height: 90%;
+  height: 90%;
 }
 
 .modal.dark,
 .modal.dark .modal-footer {
-    background-color: var(--theme-dark);
+  background-color: var(--theme-dark);
 }
 
 .modal.light,
 .modal.light .modal-footer {
-    background-color: var(--theme-light);
+  background-color: var(--theme-light);
 }
 
 /* Modal Media */
 @media only screen and (max-width: 800px) {
-    .modal {
-        width: 60%;
-    }
-    .modal .modal-content h4 {
-        font-size: 1.7em;
-    }
-}
-
-@media only screen and (max-width: 700px) {
-    .modal .modal-content h4 {
-        font-size: 1.5em;
-    }
+  .modal {
+    width: 60%;
+  }
 }
 
 @media only screen and (max-width: 600px) {
-    .modal {
-        height: 100% !important;
-        max-height: 100% !important;
-        width: 100% !important;
-        max-width: 100% !important;
-        top: 0% !important;
-        font-size: 14px;
-    }
-}
-
-@media only screen and (max-width: 500px) {
-    .modal .modal-content h4 {
-        font-size: 1.3em;
-    }
+  .modal {
+    height: 100% !important;
+    max-height: 100% !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    top: 0% !important;
+  }
 }


### PR DESCRIPTION
Due to the base sizing of fonts in https://github.com/micronaut-projects/micronaut-starter-ui/pull/24 it exasperbated the font size issue in the preview / diff modal heading on smaller devices

![Screen Shot 2021-02-05 at 8 35 30 AM](https://user-images.githubusercontent.com/3740088/107047839-df56f600-678d-11eb-8b35-8188466126d5.png)

This makes some minor adjustments to get it within reason.

![Screen Shot 2021-02-05 at 8 35 57 AM](https://user-images.githubusercontent.com/3740088/107047992-0ca3a400-678e-11eb-8032-e3098cf85de9.png)
