### PR TITLE
Add (community) to community features

### DIFF
--- a/app/launch/src/components/FeatureSelector/FeatureAvailable.js
+++ b/app/launch/src/components/FeatureSelector/FeatureAvailable.js
@@ -12,9 +12,12 @@ const FeatureAvailable = ({ feature, toggleFeatures }) => {
                 feature.selected && 'selected'
             }`}
             title={
-                feature.preview != null && feature.preview
+                (feature.preview != null && feature.preview
                     ? feature.name + ' (preview)'
-                    : feature.name
+                    : feature.name) +
+                (feature.community != null && feature.community
+                    ? ' (community)'
+                    : '')
             }
             onClick={(e) => toggleFeatures(e, feature)}
         >


### PR DESCRIPTION
Since https://github.com/micronaut-projects/micronaut-starter/issues/1062 we have added a community flag to features that are maintained by the community.

This change shows the flag on the UI alongside any "(preview)" flag, ie:

![image](https://user-images.githubusercontent.com/49317/153252082-cee71682-daf6-4cf4-898c-8d406d621346.png)

I couldn't find any tests to update