### PR TITLE
Replace Twitter icon with X icon.

### DIFF
--- a/app/launch/src/components/Links/TwitterLink.js
+++ b/app/launch/src/components/Links/TwitterLink.js
@@ -4,7 +4,7 @@ import React from 'react'
 export const TwitterLink = ({ className, theme }) => {
   const backgroundColor =
     theme === 'dark' ? 'var(--theme-light)' : 'var(--theme-dark)'
-  const color = theme === 'dark' ? 'var(--theme-dark)' : 'white'
+  const fill = theme === 'dark' ? 'var(--theme-dark)' : 'white'
 
   return (
     <a

--- a/app/launch/src/components/Links/TwitterLink.js
+++ b/app/launch/src/components/Links/TwitterLink.js
@@ -1,8 +1,6 @@
 // TwitterLink.js
 import React from 'react'
 
-import TwitterIcon from '@material-ui/icons/Twitter'
-
 export const TwitterLink = ({ className, theme }) => {
   const backgroundColor =
     theme === 'dark' ? 'var(--theme-light)' : 'var(--theme-dark)'
@@ -11,8 +9,8 @@ export const TwitterLink = ({ className, theme }) => {
   return (
     <a
       href="https://twitter.com/micronautfw"
-      aria-label="Micronaut Twitter Account"
-      title="Micronaut Twitter Account"
+      aria-label="Micronaut X Account"
+      title="Micronaut X Account"
       target="_blank"
       rel="noopener noreferrer"
       style={{
@@ -20,7 +18,17 @@ export const TwitterLink = ({ className, theme }) => {
       }}
       className={className}
     >
-      <TwitterIcon className="twitter" style={{ color }} />
+        <svg
+            aria-hidden="true"
+            focusable="false"
+            viewBox="-50 -28.5 356 256"
+            width="32px"
+        >
+            <path
+                d="M178.57 127.15 290.27 0h-26.46l-97.03 110.38L89.34 0H0l117.13 166.93L0 300.25h26.46l102.4-116.59 81.8 116.59h89.34M36.01 19.54H76.66l187.13 262.13h-40.66"
+                style={{fill: fill}}
+            />
+        </svg>
     </a>
   )
 }

--- a/app/launch/src/components/Links/TwitterLink.js
+++ b/app/launch/src/components/Links/TwitterLink.js
@@ -21,7 +21,7 @@ export const TwitterLink = ({ className, theme }) => {
         <svg
             aria-hidden="true"
             focusable="false"
-            viewBox="-50 -28.5 356 256"
+            viewBox="-100 -100 500 500"
             width="32px"
         >
             <path


### PR DESCRIPTION
closes #100

This uses the svg icon at https://upload.wikimedia.org/wikipedia/commons/5/53/X_logo_2023_original.svg

However, there is an open PR at [Update Twitter logo](https://github.com/mui/material-ui/pull/38811) to update the `material-ui` library that we use for the current Twitter icon. I wonder if should wait for it to be merged and just update dependency (although we're on 4.x and the current major is 5.x). Maybe it will be merged and released in time for our 4.3.0 release.

I haven't smoke tested this yet, because I still have issues getting it to run for me locally.