### PR TITLE
Remove next.micronaut.io.

### DIFF
--- a/app/launch/public/mn-version-feed.json
+++ b/app/launch/public/mn-version-feed.json
@@ -11,14 +11,9 @@
             "order": 1
         },
         {
-            "key": "NEXT",
-            "baseUrl": "https://next.micronaut.io",
-            "order": 2
-        },
-        {
             "key": "PREV",
             "baseUrl": "https://prev.micronaut.io",
-            "order": 3
+            "order": 2
         }
     ]
 }

--- a/dev-proxy-server/src/proxy-dev.js
+++ b/dev-proxy-server/src/proxy-dev.js
@@ -3,7 +3,7 @@ const VERSION_FEED_URL = "https://micronaut.io/launch/mn-version-feed.json";
 const { startProxy, startVersionServer } = require("./commands");
 
 /**
- * Start a version server server and proxy servers for the current
+ * Start a version server and proxy server for the current
  * Micronaut Starter versions mirroring production launch site
  * This will fetch the production feed, and create proxies for
  * each of the remote sites at incrementing ports starting at 8080

--- a/dev-proxy-server/src/starter-dev.js
+++ b/dev-proxy-server/src/starter-dev.js
@@ -4,7 +4,7 @@ const VERSION_FEED_URL = "https://micronaut.io/launch/mn-version-feed.json";
 const { startVersionServer, toLocalUrl } = require("./commands");
 
 /**
- * Start a version server server that serves up
+ * Start a version server that serves up
  * Micronaut Starter API (https://github.com/micronaut-projects/micronaut-starter)
  * you are running locally, which by default runs on port 8080
  * when started via `./gradlew :starter-web-netty:run`


### PR DESCRIPTION
next.micronaut.io. isn't used for anything, and results in a ERR_CERT_DATE_INVALID error trying to resolve the URL next.micronaut.io/versions.

fixes #102